### PR TITLE
listenAddr and listenPort were not set for RStudio

### DIFF
--- a/Rook/R/Rhttpd.R
+++ b/Rook/R/Rhttpd.R
@@ -159,6 +159,8 @@ Rhttpd <- setRefClass(
 	    if(grepl('rstudio',base::.Platform$GUI,ignore.case=TRUE)){
 		if (!missing(port))
 		    warning("RStudio has already started the web server on port ",tools:::httpdPort)
+		listenAddr <<- listen
+		listenPort <<- tools:::httpdPort
 		return(invisible())
 	    }
 


### PR DESCRIPTION
Hi Jeffrey,

First of all thanks for your great work on creating an easy to use web server/app with R.

Version 1.0-3 of Rook contains a small bug: when using R-studio, 
the listenPort and listenAddr are not set, resulting in strange behaviour when using `browse`, `start` and the lots.

Best,

Edwin de Jonge
