### PR TITLE
Avoid regex errors when running on Windows.

### DIFF
--- a/R/Brewery.R
+++ b/R/Brewery.R
@@ -27,11 +27,11 @@ Brewery <- setRefClass(
             normalizePath(file.path(root,path),mustWork=TRUE),
             silent=TRUE
          )
+         file_path_prefix <- paste0(root,url,.Platform$file.sep)
          if (!inherits(file_path, 'try-error') &&
-             grepl(paste('^',url,sep=''),path) &&
-             !grepl(paste('^',url,'$',sep=''),path) &&
-             grepl(paste('^',root,url,.Platform$file.sep,sep=''),file_path)){
-
+             grepl(paste0('^',url),path) &&
+             !grepl(paste0('^',url,'$'),path) &&
+             substr(file_path,1,nchar(file_path_prefix)) == file_path_prefix){
             oldwd <- setwd(dirname(file_path))
             on.exit(setwd(oldwd))
             res$write(


### PR DESCRIPTION
Hi,

A user of one of my packages emailed me with the following error message:

```
Error in grepl(paste("^", root, url, .Platform$file.sep, sep = ""), file_path) : 
  invalid regular expression '^C:\Users\USER\Documents\R\win-library\3.1\pkg\example/brew/', reason 'Invalid back reference'
```

This appeared to be caused by `.Platform$file.sep` being a backref in regex-land when used on Windows (i.e. `.Platform$file.sep` is `\`.

I made a minor change so that there is a char vector substring match instead of a regular expression (should be faster too, not that it matters).

Unfortunately I was unable to test whether this fixes the problem (don't have a Windows machine handy), but it does not break anything in Linux anyway.