### PR TITLE
Fix listenPort value in Rhttpd class when in RStudio environment.

### DIFF
--- a/R/Rhttpd.R
+++ b/R/Rhttpd.R
@@ -156,7 +156,7 @@ Rhttpd <- setRefClass(
 
       if(grepl('rstudio',base::.Platform$GUI,ignore.case=TRUE)){
          # RStudio has already set up host and port
-         listenPort <<- tools:::httpdPort
+         listenPort <<- tools:::httpdPort()
          if (!missing(port))
             warning("RStudio has already started the web server on port ",tools:::httpdPort)
          return(invisible())


### PR DESCRIPTION
In current code `tools:::httpdPort` is assigned - which is a function. That leads to an errors further and silent fails during start.

(same happened here: http://stackoverflow.com/questions/32842079/rstudio-rook-does-not-work)
