### PR TITLE
fix order of app removals in finalizer

### DIFF
--- a/R/Rhttpd.R
+++ b/R/Rhttpd.R
@@ -108,7 +108,7 @@ Rhttpd <- setRefClass(
 	},
 	finalize = function(){
 	    if (length(appList) == 0) return()
-	    for (i in 1:length(appList)){
+	    for (i in rev(1:length(appList))){
 		remove(appList[[i]])
 	    }
 	},


### PR DESCRIPTION
otherwise, when there's more than one app, not all apps are removed, and this error is thrown:
```R
Error in appList[[i]] : subscript out of bounds

Enter a frame number, or 0 to exit   

1: (function (x) 
x$.self$finalize())(<environment>)
2: x$.self$finalize()
3: remove(appList[[i]])
4: inherits(app, "RhttpdApp")
```