### PR TITLE
tools:::httpdPort is a dynamic variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: Rook
 Type: Package
 Title: Rook - a web server interface for R
-Version: 1.1-1
-Date: 2014-10-20
+Version: 1.1-2
+Date: 2020-12-16
 Author: Jeffrey Horner <jeffrey.horner@gmail.com>
 Maintainer: Jeffrey Horner <jeffrey.horner@gmail.com>
 Description: This package contains the Rook specification and
  convenience software for building and running Rook applications. To
  get started, be sure and read the 'Rook' help file first.
-Depends: R (>= 2.13.0)
+Depends: R (>= 3.2.0)
 Imports: utils, tools, methods, brew
 License: GPL-2
 LazyLoad: yes

--- a/R/Rhttpd.R
+++ b/R/Rhttpd.R
@@ -116,7 +116,7 @@ Rhttpd <- setRefClass(
 	    paste('http://',listenAddr,':',listenPort,appList[[i]]$path,sep='')
 	},
 	launch = function(...){
-	    .self$start(quiet=TRUE)		
+	    .self$start(quiet=TRUE)
 	    # Try to create a new app from the supplied arguments
 	    app <- RhttpdApp$new(...)
 	    if (add(app)){
@@ -156,9 +156,9 @@ Rhttpd <- setRefClass(
 
       if(grepl('rstudio',base::.Platform$GUI,ignore.case=TRUE)){
          # RStudio has already set up host and port
-         listenPort <<- tools:::httpdPort
+         listenPort <<- tools:::httpdPort()
          if (!missing(port))
-            warning("RStudio has already started the web server on port ",tools:::httpdPort)
+            warning("RStudio has already started the web server on port ",tools:::httpdPort())
          return(invisible())
       }
 
@@ -208,15 +208,15 @@ Rhttpd <- setRefClass(
 		#.self$httpdOrig <- tools:::httpd
 		#assignInNamespace(
 		#    app$name,
-		#    function(path,query,postBody,headers) 
-		#	.self$handler(app$name,path,query,postBody,headers), 
+		#    function(path,query,postBody,headers)
+		#	.self$handler(app$name,path,query,postBody,headers),
 		#    'tools'
 		#)
 	    } else {
 		assign(
-		    app$name, 
-		    function(path,query,postBody,headers) 
-			.self$handler(app$name,path,query,postBody,headers), 
+		    app$name,
+		    function(path,query,postBody,headers)
+			.self$handler(app$name,path,query,postBody,headers),
 		    tools:::.httpd.handlers.env
 		)
 	    }
@@ -292,10 +292,10 @@ Rhttpd <- setRefClass(
             ),
          env
          )
-      
+
       if(exists("HTTP_REQUEST_METHOD", env)){
         assign('REQUEST_METHOD',get("HTTP_REQUEST_METHOD", env) ,env)
-      } else {      
+      } else {
         assign('REQUEST_METHOD',ifelse(is.null(postBody),'GET','POST'),env)
       }
 


### PR DESCRIPTION
`tools:::httpdPort` was changed to a dynamic variable (`tools:::httpdPort()`) on Jan 17, 2015 (see [this](https://github.com/wch/r-source/commit/368f045c56bfef9310a61272ed65f68ad1930929#diff-511a7690b48f353bb2bb27e5ac70040466b0f9423837d502bda503717562ed3d) commit by K Hornik).

The PR implements this change when checking the port in RStudio IDE. I also added the subsequent R version dependency (non exported function changes are not advertised in R NEWS, but I assumed the next minor version 3.2.0 to be appropriate).