### PR TITLE
Avoid CRAN removal, fixes 'Found no call to: ‘R_useDynamicSymbols’'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .Rproj.user
 .Rhistory
 .RData
-.lvimrc
+.Ruserdata
+Rook*.tar.gz
+Rook*Rcheck

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: Rook - a web server interface for R
 Version: 1.2
 Date: 2022-Nov-03
-Author: Jeffrey Horner [aut], Evan Biederstedt [aut, cre]
-Maintainer: Evan Biederstedt <evan.biederstedt@gmail.com>
+Author: Jeffrey Horner <jeffrey.horner@gmail.com>
+Maintainer: Jeffrey Horner <jeffrey.horner@gmail.com>
 Description: This package contains the Rook specification and
  convenience software for building and running Rook applications. To
  get started, be sure and read the 'Rook' help file first.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: Rook
 Type: Package
 Title: Rook - a web server interface for R
-Version: 1.1-1
-Date: 2014-10-20
-Author: Jeffrey Horner <jeffrey.horner@gmail.com>
-Maintainer: Jeffrey Horner <jeffrey.horner@gmail.com>
+Version: 1.2
+Date: 2022-Nov-03
+Author: Jeffrey Horner [aut], Evan Biederstedt [aut, cre]
+Maintainer: Evan Biederstedt <evan.biederstedt@gmail.com>
 Description: This package contains the Rook specification and
  convenience software for building and running Rook applications. To
  get started, be sure and read the 'Rook' help file first.

--- a/src/rook.c
+++ b/src/rook.c
@@ -51,12 +51,12 @@ SEXP rawmatch( SEXP needle, SEXP haystack, SEXP allMatches){
    return newans;
 }
 
-R_CallMethodDef callMethods[]  = {
+R_CallMethodDef CallEntries[]  = {
    {"rawmatch", (DL_FUNC) &rawmatch, 3},
    {NULL, NULL, 0}
 };
 
-void R_init_Rook(DllInfo *info) {
-   R_registerRoutines(info, NULL, callMethods, NULL, NULL);
+void R_init_Rook(DllInfo *dll) {
+   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
    R_useDynamicSymbols(dll, FALSE);
 }

--- a/src/rook.c
+++ b/src/rook.c
@@ -58,5 +58,5 @@ R_CallMethodDef callMethods[]  = {
 
 void R_init_Rook(DllInfo *info) {
    R_registerRoutines(info, NULL, callMethods, NULL, NULL);
-   /*	R_useDynamicSymbols(info, FALSE);*/
+   R_useDynamicSymbols(dll, FALSE);
 }

--- a/src/rook.c
+++ b/src/rook.c
@@ -27,10 +27,15 @@ SEXP rawmatch( SEXP needle, SEXP haystack, SEXP allMatches){
       error_return("all must be a logical vector")
          all = LOGICAL(allMatches)[0];
 
-   if (n2 > n1) return allocVector(INTSXP,0);
+   if (n2 > n1) {
+      SEXP result = PROTECT(allocVector(INTSXP,0));
+      UNPROTECT(1);
+
+      return result;
+   }
 
    k = 0;
-   ans = allocVector(INTSXP, all? (int)(n1 / n2) : 1);
+   ans = PROTECT(allocVector(INTSXP, all? (int)(n1 / n2) : 1));
 
    for (i = 0; i < n1; i++){
       if (x1[i] == x2[0]){
@@ -46,8 +51,10 @@ SEXP rawmatch( SEXP needle, SEXP haystack, SEXP allMatches){
    }
    if (k == LENGTH(ans)) return ans;
 
-   newans = allocVector(INTSXP,k);
+   newans = PROTECT(allocVector(INTSXP,k));
    while(k) {k--;INTEGER(newans)[k] = INTEGER(ans)[k];}
+
+   UNPROTECT(2);
    return newans;
 }
 


### PR DESCRIPTION
This PR is to avoid the planned removal of Rook from CRAN

Here's the bug:
"""
Version: 1.1-1
Check: compiled code
Result: NOTE
    File ‘Rook/libs/Rook.so’:
     Found no call to: ‘R_useDynamicSymbols’
    
    It is good practice to register native routines and to disable symbol
    search.
    
    See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
Flavors: [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/Rook-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/Rook-00check.html)
"""